### PR TITLE
`npm update`

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "npm-update-bug-1",
-  "version": "0.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "alpha/esm": {
-      "version": "0.0.0",
-      "workspaces": [
-        "alpha/*"
-      ]
-    },
-    "node_modules/@csstools/some-package--esm": {
-      "resolved": "alpha/esm",
-      "link": true
-    }
-  }
+	"name": "npm-update-bug-1",
+	"version": "0.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"alpha/esm": {
+			"version": "0.0.0",
+			"workspaces": [
+				"alpha/*"
+			]
+		},
+		"node_modules/@csstools/some-package--esm": {
+			"resolved": "alpha/esm",
+			"link": true
+		}
+	}
 }

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,19 +1,18 @@
 {
-	"name": "npm-update-bug-1",
-	"version": "0.0.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"alpha/esm": {
-			"name": "@csstools/some-package--esm",
-			"version": "0.0.0",
-			"workspaces": [
-				"alpha/*"
-			]
-		},
-		"node_modules/@csstools/some-package--esm": {
-			"resolved": "alpha/esm",
-			"link": true
-		}
-	}
+  "name": "npm-update-bug-1",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "alpha/esm": {
+      "version": "0.0.0",
+      "workspaces": [
+        "alpha/*"
+      ]
+    },
+    "node_modules/@csstools/some-package--esm": {
+      "resolved": "alpha/esm",
+      "link": true
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			]
 		},
 		"alpha/esm": {
-			"name": "@csstools/some-package--esm",
 			"version": "0.0.0",
 			"workspaces": [
 				"alpha/*"


### PR DESCRIPTION
Running `npm update` erased the `name` field from `package-lock.json`

Running `npm audit` is very weird now :

```
npm audit 
# npm audit report

esm  <3.1.0
Severity: moderate
Regular Expression Denial of Service - https://github.com/advisories/GHSA-qx4v-6gc5-f2vv
No fix available
alpha/esm
node_modules/@csstools/some-package--esm

1 moderate severity vulnerability

Some issues need review, and may require choosing
a different dependency.

```

Node/npm thinks there is a package `esm` referenced/used somewhere simply because there is a workspace folder with name `esm`.

This aspect shows that there is some confusion in the npm cli around "what is the package?".

I would expect the npm cli to always and consistently know that `@csstools/some-package--esm` is the package and never fallback to the directory name `esm`.